### PR TITLE
Fixing Heroku Support

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn slackbridge --log-file -
+web: gunicorn wsgi --log-file -


### PR DESCRIPTION
Heroku support is currently broken. Issuing a small commit to fix heroku support! :-)
* Editing Procfile to accurately reflect the wsgi.py instead of slackbridge.py
* Reference  8b7eff6ddb94a054ffba56d9b619f2fcf4daeadc in which slackbridge.py was refactored and renamed.